### PR TITLE
Add quotes around command for termite terminal

### DIFF
--- a/qn.py
+++ b/qn.py
@@ -62,7 +62,7 @@ def terminal_open(terminal, command, title=None):
     else:
         generated_command = terminal + ' -T "' + title + '"'
 
-    os.system(generated_command + " -e " + command)
+    os.system(generated_command + " -e \"" + command + "\"")
 
 
 def sizeof_fmt(num, suffix='B'):


### PR DESCRIPTION
With the following configuration:

- Terminal = termite
- Editor = vim

qn was only opening vim, without any file loaded. Adding double quotes around the command solve the issue